### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
+LABEL org.opencontainers.image.source="https://github.com/PCJones/MediathekArr"
 
 RUN apt-get update && apt-get install -y tar xz-utils && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md