### PR TITLE
Add support for the Homarr SABnzbd integration …

### DIFF
--- a/MediathekArr/Controllers/DownloadController.cs
+++ b/MediathekArr/Controllers/DownloadController.cs
@@ -21,6 +21,7 @@ public partial class DownloadController(DownloadService downloadService, Config 
             "version" => Ok(new { version = "4.3.3" }),
             "get_config" => Content(ConfigResponse, "application/json"),
             "fullstatus" => Content(FullStatusResponse, "application/json"),
+            "translate" => (value == "ping") ? Ok(new { value = "pong" }) : Ok(new { value = value }),
             "queue" => Ok(GetQueue()),
             "history" => (name == "delete" && !string.IsNullOrEmpty(value))
                 ? DeleteHistoryItem(value, del_files.GetValueOrDefault() == 1)

--- a/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
+++ b/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
@@ -27,7 +27,7 @@ public class SabnzbdHistoryItem
     public SabnzbdDownloadStatus Status { get; set; }
 
     [JsonPropertyName("completed")]
-    public long Completed { get; set; };
+    public long Completed { get; set; }
 
     [JsonPropertyName("nzo_id")]
     public string Id { get; set; }

--- a/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
+++ b/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
@@ -27,7 +27,7 @@ public class SabnzbdHistoryItem
     public SabnzbdDownloadStatus Status { get; set; }
 
     [JsonPropertyName("completed")]
-    public long Completed => DateTimeOffset.Now.ToUnixTimeSeconds();
+    public long Completed { get; set; };
 
     [JsonPropertyName("nzo_id")]
     public string Id { get; set; }

--- a/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
+++ b/MediathekArr/Models/SABnzbd/SabnzbdHistoryItem.cs
@@ -26,8 +26,14 @@ public class SabnzbdHistoryItem
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public SabnzbdDownloadStatus Status { get; set; }
 
+    [JsonPropertyName("completed")]
+    public long Completed => DateTimeOffset.Now.ToUnixTimeSeconds();
+
     [JsonPropertyName("nzo_id")]
     public string Id { get; set; }
+
+    [JsonPropertyName("postproc_time")]
+    public int PostprocTime => 0;
 
     [JsonPropertyName("name")]
     public string Title { get; set; }

--- a/MediathekArr/Models/SABnzbd/SabnzbdQueue.cs
+++ b/MediathekArr/Models/SABnzbd/SabnzbdQueue.cs
@@ -7,6 +7,9 @@ public class SabnzbdQueue
     [JsonPropertyName("paused")]
     public bool Paused => false;
 
+    [JsonPropertyName("kbpersec")]
+    public string KbPerSec => "0";
+
     [JsonPropertyName("slots")]
     public List<SabnzbdQueueItem> Items { get; set; }
 }

--- a/MediathekArr/Services/DownloadService.cs
+++ b/MediathekArr/Services/DownloadService.cs
@@ -280,6 +280,7 @@ public partial class DownloadService
                 DownloadTime = 0,
                 Storage = null,
                 Status = SabnzbdDownloadStatus.Failed,
+                Completed = DateTimeOffset.Now.ToUnixTimeSeconds(),
                 Id = queueItem.Id
             });
         }
@@ -387,6 +388,7 @@ public partial class DownloadService
             DownloadTime = (int)stopwatch.Elapsed.TotalSeconds,
             Storage = mkvPath,
             Status = queueItem.Status,
+            Completed = DateTimeOffset.Now.ToUnixTimeSeconds(),
             Id = queueItem.Id
         };
         _downloadHistory.Add(historyItem);


### PR DESCRIPTION
… by mocking the translate endpoint
… by returning 0 for `kbpersec` in the `/queue` response
… by returning the `completed` timestamp (working as intended) and 0 for `postproc_time` in the `/history` response

Currently it's configured to return a download speed of 0kbps and translate every value to the input value, except for ping, which is translated to pong. Pausing or cancelling downloads still doesn't work but at least you're able to create the integration and widget without any problems.