### PR TITLE
Use different api4.thetvdb.com endpoint for getting all the series

### DIFF
--- a/api/v1/get_show.php
+++ b/api/v1/get_show.php
@@ -105,31 +105,56 @@ function fetchAndCacheSeriesData($db, $tvdbId, $apiKey, $debug = false) {
         return ["status" => "error", "message" => "Failed to retrieve valid token from TVDB"];
     }
 
-    $curl = curl_init("https://api4.thetvdb.com/v4/series/$tvdbId/extended?meta=episodes&short=true");
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($curl, CURLOPT_HTTPHEADER, [
-        "Authorization: Bearer $token",
-        "Accept: application/json"
-    ]);
-    $response = curl_exec($curl);
+    // Fetch all episodes with German translations using paginated endpoint
+    $allEpisodes = [];
+    $series = null;
+    $page = 0;
 
-    // Check for Curl errors
-    if (curl_errno($curl)) {
-        $error_msg = curl_error($curl);
+    do {
+        $url = "https://api4.thetvdb.com/v4/series/$tvdbId/episodes/default/deu?page=$page";
+        $curl = curl_init($url);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, [
+            "Authorization: Bearer $token",
+            "Accept: application/json"
+        ]);
+        $response = curl_exec($curl);
+
+        // Check for Curl errors
+        if (curl_errno($curl)) {
+            $error_msg = curl_error($curl);
+            curl_close($curl);
+            return ["status" => "error", "message" => "Curl error: " . $error_msg];
+        }
         curl_close($curl);
-        return ["status" => "error", "message" => "Curl error: " . $error_msg];
-    }
-    curl_close($curl);
+        
+        // Decode response and check for errors
+        $data = json_decode($response, true);
+        if (!$data || $data['status'] !== 'success') {
+            return ["status" => "error", "message" => "Failed to fetch data from TVDB"];
+        }
 
-    // Decode response and check for errors
-    $data = json_decode($response, true);
-    if (!$data || $data['status'] !== 'success') {
-        return ["status" => "error", "message" => "Failed to fetch data from TVDB"];
-    }
+        if ($series === null) {
+            $series = [
+                "name" => $data['data']['name'],
+                "aliases" => $data['data']['aliases'],
+                "nextAired" => $data['data']['nextAired'],
+                "lastAired" => $data['data']['lastAired'],
+                "lastUpdated" => $data['data']['lastUpdated']
+            ];
+        }
+
+        $episodes = $data['data']['episodes'] ?? [];
+        $allEpisodes = array_merge($allEpisodes, $episodes);
+
+        $nextPage = $data['links']['next'] ?? null;
+        $page++;
+    } while ($nextPage !== null);
+
+    $series['episodes'] = $allEpisodes;
 
     try {
-        $series = $data['data'];
-		$seriesName = $series['name'];
+        $seriesName = $series['name'];
 		$translations = fetchTranslationTitles($tvdbId, $seriesName, $seriesName);
 		$englishName = $translations['englishTitle'];
 		$germanName  = $translations['germanTitle'];


### PR DESCRIPTION
Hi

I had a problem with the series "Mit offenen Karten" in french "Les Dessous des Cartes". The function `GetShowInfoByTvdbId` in `ItemLookupService` uses the `get_show.php?tvdid={tvdbid}` but in the specific case of "Mit offenen Karten" `get_show` returned the episodes with the french episode titles. Because of this the `MatchingStrategy.ItemTitleExact` failed since it's comparing German to French episode titles.

With the endpoint `https://api4.thetvdb.com/v4/series/$tvdbId/episodes/default/deu` it's guaranteed that the episode titles are in German as long as their is a translation.

I tested the change with "Mit offenen Karten" and "ZDF Magazin Royale".

I also added a new rule for the rulesets but i read in an issues that @PCJones plans to make that more dynamic anyway. But to be complete here the added rule:

```json
{
      "id": 98,
      "mediaId": 63,
      "topic": "Aktuelles und Gesellschaft - Hintergrund",
      "priority": 99,
      "filters": "[{\"attribute\":\"duration\",\"type\":\"GreaterThan\",\"value\":\"10\"}]",
      "titleRegexRules": "[{\"type\":\"regex\",\"field\":\"title\",\"pattern\":\"^Mit offenen Karten - (.+)$\"}]",
      "episodeRegex": "",
      "seasonRegex": "",
      "matchingStrategy": "ItemTitleExact",
      "media": {
        "media_id": 63,
        "media_name": "Mit offenen Karten",
        "media_type": "show",
        "media_tmdbId": null,
        "media_imdbId": "n/a",
        "media_tvdbId": 109331
      }
}
```